### PR TITLE
feat: open documentation in a split

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
 Plug 'ANGkeith/telescope-terraform-doc.nvim'
 ```
+### Packer
+```lua
+use {
+    "nvim-telescope/telescope.nvim",
+    requires = {
+        { "nvim-lua/plenary.nvim" },
+        { "nvim-telescope/telescope-terraform-doc.nvim" },
+    },
+}
+```
 ## Setup
 Add the following to your `init.vim`:
 ``` lua
@@ -54,10 +64,12 @@ nnoremap <space>otk :Telescope terraform_doc full_name=hashicorp/kubernetes<cr>
 ```
 
 ### Configurable settings
-| Keys                     | Description                                                      | Options                    |
-|--------------------------|------------------------------------------------------------------|----------------------------|
-| `url_open_command`       | The shell command to open the url                                | string (default: `open`)   |
-| `latest_provider_symbol` | The symbol for indicating that the current version is the latest | string (default: `*`)      |
+| Keys                     | Description                                                      | Options                           |
+|--------------------------|------------------------------------------------------------------|-----------------------------------|
+| `url_open_command`       | The shell command to open the url                                | string (default: `open`)          |
+| `latest_provider_symbol` | The symbol for indicating that the current version is the latest | string (default: `*`)             |
+| `wincmd`                 | Command to open documentation in a split window                  | string (default: `botright vnew`) |
+| `wrap`                   | Wrap lines in a documentation in a split window                  | string (default: `nowrap`)        |
 
 ```lua
 require("telescope").setup({
@@ -65,7 +77,16 @@ require("telescope").setup({
     terraform_doc = {
       url_open_command = "xdg-open",
       latest_provider_symbol = "  ",
+      wincmd = "botright vnew",
+      wrap = "nowrap",
     }
   }
 })
 ```
+
+#### Telescope key mappings
+
+| key     | Usage                                      |
+|---------|--------------------------------------------|
+| `<cr>`  | Open documentation with `url_open_command` |
+| `<c-d>` | Open documentation in a split window       |

--- a/lua/telescope/_extensions/terraform_doc/actions.lua
+++ b/lua/telescope/_extensions/terraform_doc/actions.lua
@@ -14,6 +14,28 @@ function M.url_opener(opts)
   end
 end
 
+function M.doc_view(opts)
+  return function(prompt_bufnr)
+    local selection = action_state.get_selected_entry()
+    actions.close(prompt_bufnr)
+
+    local content = M_api.get_docs_content(selection.id)
+    vim.api.nvim_command(opts.wincmd)
+
+    local buf = vim.api.nvim_get_current_buf()
+
+    vim.api.nvim_buf_set_name(0, selection.category .. " " .. selection.title)
+
+    vim.api.nvim_buf_set_option(0, "buftype", "nofile")
+    vim.api.nvim_buf_set_option(0, "swapfile", false)
+    vim.api.nvim_buf_set_option(0, "filetype", "markdown")
+    vim.api.nvim_buf_set_option(0, "bufhidden", "wipe")
+    vim.api.nvim_command("setlocal wrap")
+    vim.api.nvim_command("setlocal cursorline")
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
+  end
+end
+
 function M.url_opener_module(opts)
   return function(prompt_bufnr)
     local selection = action_state.get_selected_entry()

--- a/lua/telescope/_extensions/terraform_doc/api.lua
+++ b/lua/telescope/_extensions/terraform_doc/api.lua
@@ -97,6 +97,19 @@ function M.get_docs_url(full_name, version, category, resource_slug)
 end
 
 ---
+---Returns the documentation in markdown format
+function M.get_docs_content(id)
+  local resp = vim.fn.json_decode(curl.request({
+    -- https://registry.terraform.io/v2/provider-docs/522139
+    url = base_url .. "/v2/provider-docs/" .. id,
+    method = "get",
+    accept = "application/json",
+  }).body)
+  local content = vim.split(resp.data.attributes.content, "\n")
+  return content
+end
+
+---
 ---Returns the url to the terraform registry module
 function M.get_docs_url_module(full_name, provider_name)
   return base_url .. "/modules/" .. full_name .. "/" .. provider_name .. "/latest"

--- a/lua/telescope/_extensions/terraform_doc/builtin.lua
+++ b/lua/telescope/_extensions/terraform_doc/builtin.lua
@@ -28,8 +28,9 @@ function M.search(opts)
       results = M_api.get_provider_resources(provider_version_meta.id),
       entry_maker = M_make_entry.gen_from_run(opts),
     }),
-    attach_mappings = function(_)
+    attach_mappings = function(_, map)
       actions.select_default:replace(M_actions.url_opener(opts))
+      map("i", "<c-d>", M_actions.doc_view(opts))
       return true
     end,
   }):find()

--- a/lua/telescope/_extensions/terraform_doc/config.lua
+++ b/lua/telescope/_extensions/terraform_doc/config.lua
@@ -1,14 +1,18 @@
 local M = {
   opts = {
     url_open_command = "open",
-    version = "latest",
     latest_provider_symbol = "*",
+    version = "latest",
+    wincmd = "botright vnew",
+    wrap = "nowrap",
   },
 }
 
 M.setup = function(opts)
   M.opts.url_open_command = opts.url_open_command or M.opts.url_open_command
   M.opts.latest_provider_symbol = opts.latest_provider_symbol or M.opts.latest_provider_symbol
+  M.opts.wincmd = opts.wincmd or M.opts.wincmd
+  M.opts.wrap = opts.wrap or M.opts.wrap
 end
 
 return M

--- a/lua/telescope/_extensions/terraform_doc/local_api.lua
+++ b/lua/telescope/_extensions/terraform_doc/local_api.lua
@@ -1,6 +1,10 @@
 local curl = require("plenary.curl")
 
 local M = {}
+if not vim.g.terraform_doc_git_namespace then
+  vim.g.terraform_doc_git_namespace = "ANGkeith"
+end
+
 local base_url = "https://raw.githubusercontent.com/"
   .. vim.g.terraform_doc_git_namespace
   .. "/telescope-terraform-doc.nvim/api"

--- a/lua/telescope/_extensions/terraform_doc/make_entry.lua
+++ b/lua/telescope/_extensions/terraform_doc/make_entry.lua
@@ -22,6 +22,7 @@ function M.gen_from_run(opts)
 
   return function(entry)
     local result = {
+      id = entry.id,
       ordinal = entry.attributes.title,
       category = entry.attributes.category,
       title = entry.attributes.title,


### PR DESCRIPTION
Hi @ANGkeith 
This PR adds ability by opening Terraform documentation in a split window in markdown format by pressing `<C-D>` keymap.

I've also add couple options to define split window behaviour and updated documentation
Example result:
<img width="1883" alt="Screenshot 2022-04-19 at 12 23 57" src="https://user-images.githubusercontent.com/28604639/163973147-c004bc01-07c8-4700-bd19-0e79951ce84c.png">

