### PR TITLE
fix: open url with system default. works for windows as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,19 @@ nnoremap <space>otk :Telescope terraform_doc full_name=hashicorp/kubernetes<cr>
 ### Configurable settings
 | Keys                     | Description                                                      | Options                             |
 |--------------------------|------------------------------------------------------------------|-------------------------------------|
-| `url_open_command`       | The shell command to open the url                                | string (default: `open`/`xdg-open`) |
+| `url_open_handler`       | A function that will be used to open the url                     | function                            |
 | `latest_provider_symbol` | The symbol for indicating that the current version is the latest | string (default: `*`)               |
 | `wincmd`                 | Command to open documentation in a split window                  | string (default: `botright vnew`)   |
 | `wrap`                   | Wrap lines in a documentation in a split window                  | string (default: `nowrap`)          |
 
 ```lua
+local function customOpen(url)
+    vim.fn.system('open -a Safari "' .. url .. '"')
+end
 require("telescope").setup({
   extensions = {
     terraform_doc = {
-      url_open_command = vim.fn.has("macunix") and "open" or "xdg-open",
+      url_open_handler = customOpen,
       latest_provider_symbol = "  ",
       wincmd = "botright vnew",
       wrap = "nowrap",
@@ -88,5 +91,5 @@ require("telescope").setup({
 
 | key     | Usage                                      |
 |---------|--------------------------------------------|
-| `<cr>`  | Open documentation with `url_open_command` |
+| `<cr>`  | Open documentation with `url_open_handler` |
 | `<c-d>` | Open documentation in a split window       |

--- a/lua/telescope/_extensions/terraform_doc/actions.lua
+++ b/lua/telescope/_extensions/terraform_doc/actions.lua
@@ -10,7 +10,7 @@ function M.url_opener(opts)
     actions.close(prompt_bufnr)
 
     local url = M_api.get_docs_url(opts.full_name, opts.version, selection.category, selection.slug)
-    vim.ui.open(url)
+    opts.url_open_handler(url)
   end
 end
 
@@ -41,7 +41,7 @@ function M.url_opener_module(opts)
     local selection = action_state.get_selected_entry()
     actions.close(prompt_bufnr)
     local url = M_api.get_docs_url_module(selection.full_name, selection.provider_name)
-    vim.ui.open(url)
+    opts.url_open_handler(url)
   end
 end
 

--- a/lua/telescope/_extensions/terraform_doc/actions.lua
+++ b/lua/telescope/_extensions/terraform_doc/actions.lua
@@ -10,7 +10,7 @@ function M.url_opener(opts)
     actions.close(prompt_bufnr)
 
     local url = M_api.get_docs_url(opts.full_name, opts.version, selection.category, selection.slug)
-    os.execute(string.format('%s "%s"', opts.url_open_command, url))
+    vim.ui.open(url)
   end
 end
 
@@ -41,7 +41,7 @@ function M.url_opener_module(opts)
     local selection = action_state.get_selected_entry()
     actions.close(prompt_bufnr)
     local url = M_api.get_docs_url_module(selection.full_name, selection.provider_name)
-    os.execute(string.format('%s "%s"', opts.url_open_command, url))
+    vim.ui.open(url)
   end
 end
 

--- a/lua/telescope/_extensions/terraform_doc/config.lua
+++ b/lua/telescope/_extensions/terraform_doc/config.lua
@@ -7,7 +7,18 @@ local M = {
   },
 }
 
+local function open(url)
+  if vim.fn.has("mac") == 1 then
+    vim.fn.system('open "' .. url .. '"')
+  elseif vim.fn.has("unix") == 1 then
+    vim.fn.system('xdg-open "' .. url .. '"')
+  elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+    vim.fn.system('start "" "' .. url .. '"')
+  end
+end
+
 M.setup = function(opts)
+  M.opts.url_open_handler = opts.url_open_handler or vim.ui.open or open
   M.opts.latest_provider_symbol = opts.latest_provider_symbol or M.opts.latest_provider_symbol
   M.opts.wincmd = opts.wincmd or M.opts.wincmd
   M.opts.wrap = opts.wrap or M.opts.wrap

--- a/lua/telescope/_extensions/terraform_doc/config.lua
+++ b/lua/telescope/_extensions/terraform_doc/config.lua
@@ -1,6 +1,5 @@
 local M = {
   opts = {
-    url_open_command = vim.fn.has("macunix") and "open" or "xdg-open",
     latest_provider_symbol = "*",
     version = "latest",
     wincmd = "botright vnew",
@@ -9,7 +8,6 @@ local M = {
 }
 
 M.setup = function(opts)
-  M.opts.url_open_command = opts.url_open_command or M.opts.url_open_command
   M.opts.latest_provider_symbol = opts.latest_provider_symbol or M.opts.latest_provider_symbol
   M.opts.wincmd = opts.wincmd or M.opts.wincmd
   M.opts.wrap = opts.wrap or M.opts.wrap


### PR DESCRIPTION
use vim.ui.open(url). this uses the system standard to open urls. I couldn't get os.execute to work on windows and this is a more general approach. I cannot test this on linux and mac right now but according to the docs this should work.